### PR TITLE
Reworked README and directory-specific settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ Plug 'tibabit/vim-templates'
   The argument provided is the name of the template file, in most cases the extension of the file.
   If no argument is provided file extension is extracted from file name (e.g. ``:TemplateInit cpp``)
 
-
 - `TemplateExpand`-  Does not take any argument, expands all the placeholders present in file.
   Helpful for updating an existing file
+
+## Auto initialization
+By default auto initialization is set to true, so whenever a new file is created,
+the file is automatically initialized if a template matches.
+This can be disabled by setting `g:tmpl_auto_initialize` to `0` in your `.vimrc`.
 
 # Customization
 ## Creating your own templates
@@ -46,10 +50,14 @@ int main(int argc, char** argv)
 ```
 - `{{NAME}}`, `{{EMAIL}}`, `{{FILE}}` and `{{TODAY}}`
 defined above are placeholders, which are expanded as soon as you call
-``:TemplateInit cppmain``.
+``:TemplateExpand``.
+- In a new file type ``:TemplateInit cppmain`` to both place the above
+  content inside the file and expand the placeholders.
+
 
 ### Search paths
 The plugin searches for templates as follows
+
 1. In folders named `templates` recursively up the directory tree,
    i.e. first in a directory `templates` under the current working
    directory, then in `../templates`, then '../../templates', ...
@@ -128,7 +136,4 @@ The Following placeholders are currently supported by this plugin
 - `MACRO_GUARD_FULL` : Same as `MACRO_GUARD`, except relative path is used in place of file name. e.g. `relative/to/filename.h -> RELATIVE_TO_FILENAME_H`
 - `CLASS` : class name, same as `FILE`
 - `CURSOR` : This is a spacial placeholder, it does not expand into anything but the cursor is placed at this location after the template expansion
-
-## Auto initialization
-By default auto initialization is set to true, so whenever a new file is created, file is automatically initialized with matching template. However you can dissable it by seting `g:tmpl_auto_initialize` to `0` in your .vimrc file.
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ Plug 'tibabit/vim-templates'
 
 # Usage
 ## Using default templates
-- `TemplateInit` - Takes 0 or more argument and initializes file with template and expands all placeholders defined in the template. Argument provided is name of the template file, in most cases extension of the file. If no argument is provided file extension is extracted from file name (e.g. :TemplateInit cpp)
+- `TemplateInit` - Takes 0 or more arguments, initializes file with the template and expands all placeholders defined in the template.
+  The argument provided is the name of the template file, in most cases the extension of the file.
+  If no argument is provided file extension is extracted from file name (e.g. ``:TemplateInit cpp``)
 
 
-- `TemplateExpand`-  Does not take any argument, expands all the placeholders present in file. Helpful in updating existing file
+- `TemplateExpand`-  Does not take any argument, expands all the placeholders present in file.
+  Helpful for updating an existing file
 
 # Customization
 ## Creating your own templates
 
-- Create a file <template_name>.template. e.g if you want to create a template file for c++ main file you can name it cppmain.template or cppm.template
+- Create a file <template_name>.template. e.g if you want to create a template file for a c++ main file
+  you can name it cppmain.template or cppm.template
 - Open the file and edit template
 
 ```CPP
@@ -40,7 +44,9 @@ int main(int argc, char** argv)
 	return 0;
 }
 ```
-- Add template directory to template search path in .vimrc file. For example if you template is present in templates directory under HOME then add following line in your .vimrc file
+- Add template directory to template search path in .vimrc file.
+  For example if your template is present in the ``templates`` directory under ``$HOME`` then
+  add following line in your ``.vimrc`` file
 
 ```
 set g:tmpl_search_paths = ['~/templates']
@@ -52,10 +58,11 @@ set g:tmpl_search_paths = ['~/templates']
 2. search paths defined by g:tmpl_search_paths in .vimrc file
 3. `templates` folder in plugin directory
 
-`{{NAME}}, {{EMAIL}}, {{FILE}} and {{TODAY}}`, defined above are placeholders which are expanded to their default values or as configured in .vimrc file
+`{{NAME}}`, `{{EMAIL}}`, `{{FILE}}` and `{{TODAY}}`, defined above are placeholders
+which are expanded to their default values or as configured in your `.vimrc` file
 
 ### Placeholders
-Following are the list of placeholders currently supprted by this plugin
+The Following placeholders are currently supported by this plugin
 
 #### Date & Time
 - `DAY` : Day of the week in short form (Mon, Tue, Wed, etc,)

--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ set g:tmpl_search_paths = ['~/templates']
 ```
 - Reopen vim and you are good to go.
 
-**NOTE:** Templates are searched in following order
-1. `templates` folder under current working directory
-2. search paths defined by g:tmpl_search_paths in .vimrc file
-3. `templates` folder in plugin directory
+### Search paths for templates
+Templates are searched as follows
+1. In folders named `templates` recursively up the directory tree,
+   i.e. first in a directory `templates` under the current working
+   directory, then in `../templates`, then '../../templates', ...
+2. In search paths defined by `g:tmpl_search_paths` in your `.vimrc` file
+3. The `templates` folder in this plugin's directory
 
 `{{NAME}}`, `{{EMAIL}}`, `{{FILE}}` and `{{TODAY}}`, defined above are placeholders
 which are expanded to their default values or as configured in your `.vimrc` file

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Plug 'tibabit/vim-templates'
 
 # Customization
 ## Creating your own templates
-
-- Create a file <template_name>.template. e.g if you want to create a template file for a c++ main file
-  you can name it cppmain.template or cppm.template
-- Open the file and edit template
-
+- Create a file `<template_name>.template` inside a folder which is searched
+  by the plugin( [see below](#Search paths)),
+  e.g. if you want to create a template file for a c++ main file you
+  can name it `cppmain.template` or `cppm.template`
+- Open the file and edit, for example
 ```CPP
 /**
  * @author		: {{NAME}} ({{EMAIL}})
@@ -44,25 +44,51 @@ int main(int argc, char** argv)
 	return 0;
 }
 ```
-- Add template directory to template search path in .vimrc file.
-  For example if your template is present in the ``templates`` directory under ``$HOME`` then
-  add following line in your ``.vimrc`` file
+- `{{NAME}}`, `{{EMAIL}}`, `{{FILE}}` and `{{TODAY}}`
+defined above are placeholders, which are expanded as soon as you call
+``:TemplateInit cppmain``.
 
-```
-set g:tmpl_search_paths = ['~/templates']
-```
-- Reopen vim and you are good to go.
-
-### Search paths for templates
-Templates are searched as follows
+### Search paths
+The plugin searches for templates as follows
 1. In folders named `templates` recursively up the directory tree,
    i.e. first in a directory `templates` under the current working
    directory, then in `../templates`, then '../../templates', ...
 2. In search paths defined by `g:tmpl_search_paths` in your `.vimrc` file
 3. The `templates` folder in this plugin's directory
 
-`{{NAME}}`, `{{EMAIL}}`, `{{FILE}}` and `{{TODAY}}`, defined above are placeholders
-which are expanded to their default values or as configured in your `.vimrc` file
+If you want to add a custom directory to the search path,
+e.g. if you placed them inside a ``templates`` directory under ``$HOME`` then
+add the following line in your ``.vimrc`` file:
+```
+set g:tmpl_search_paths = ['~/templates']
+```
+
+### Configuring the placeholder values
+- The values into which certain placeholders expand may be influenced
+  by settings in your `.vimrc`. For example `PROJECT` expands into the
+  value of the variable `g:tmpl_project`. For more details see the
+  list below.
+- Other than that the expansion may also be influenced on a per-directory basis.
+  If a matching template file is found in one of the directories of the
+  search path, the plugin also checks whether a file called `tmpl_settings.vim`
+  exists in the *same* directory. Note, than *no other* search directories
+  are checked.
+  If this is the case all its settings take preference over the ``.vimrc``
+- For example: In general you want the placeholder ``EMAIL`` to expand to
+  ``john.doe@example.com`` in your templates, hence you place
+  ```
+  let g:tmpl_author_email = 'john.doe@example.com'
+  ```
+  in your ``.vimrc``.   
+  In the projects inside the folder `$HOME/my_cool_stuff`, however,
+  you want your templates to show the email address ``johns_projects@example.com``.
+  So inside ``$HOME/templates`` you place a file ``$HOME/my_cool_stuff/tmpl_settings.vim``
+  with content
+  ```
+  let g:tmpl_author_email = 'johns_projects@example.com'
+  ```
+  and all template files in ``$HOME/my_cool_stuff`` will now have `EMAIL`
+  expanding to the latter value.
 
 ### Placeholders
 The Following placeholders are currently supported by this plugin
@@ -96,8 +122,8 @@ The Following placeholders are currently supported by this plugin
 - `COPYRIGHT` : Copyright message, `g:tmpl_copyright`, default : `Copyright (c) g:tmpl_company`
 
 #### Others
-- `PROJECT` : Name of the project, `g:tmpl_project`, default: `''`
-- `COMPANY` : Name of the company, `g:tmpl_company`, default: `''`
+- `PROJECT` : Name of the project, `g:tmpl_project`, default: not expanded
+- `COMPANY` : Name of the company, `g:tmpl_company`, default: not expanded
 - `MACRO_GUARD` : Macro guard for use in c/c++ files. `filename.h -> FILENAME_H`. All dots(.) and dashes (-) present in filename are converted into underscores (_).
 - `MACRO_GUARD_FULL` : Same as `MACRO_GUARD`, except relative path is used in place of file name. e.g. `relative/to/filename.h -> RELATIVE_TO_FILENAME_H`
 - `CLASS` : class name, same as `FILE`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Plug 'tibabit/vim-templates'
 # Customization
 ## Creating your own templates
 - Create a file `<template_name>.template` inside a folder which is searched
-  by the plugin( [see below](#Search paths)),
+  by the plugin( [see below](#search-paths)),
   e.g. if you want to create a template file for a c++ main file you
   can name it `cppmain.template` or `cppm.template`
 - Open the file and edit, for example

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -175,10 +175,32 @@ function <SID>ExpandAllTemplates()
     endif
 endfunction
 
+" If the settings file exits in the template directory, then
+" it is read before expanding the templates. This can be used
+" to populate the tmpl_ ... variables with values specific to
+" a project or subtree
+let s:settings_file = "tmpl_settings.vim"
+
+" Try read a default varibles file if it exists
+function <SID>TryReadSettings(template_path)
+    let l:var_path = fnameescape(a:template_path.'/'.s:settings_file)
+    echo l:var_path
+    if (filereadable(l:var_path))
+        for line in readfile(l:var_path)
+            " Ignore lines that do not actually set our
+            " variables (for security reasons)
+            if line =~ '^let g:tmpl_'
+                execute l:line
+            endif
+        endfor
+    endif
+endfunction
+
 " Initialize template from given template search path
 function <SID>InitializeTemplateForExtension(extension, template_path)
     let l:template_path = fnameescape(a:template_path.'/'.a:extension.'.template')
     if (filereadable(l:template_path))
+        call <SID>TryReadSettings(a:template_path)
         execute 'silent 0r '.l:template_path
         return 1
     endif

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -168,9 +168,9 @@ function <SID>ExpandAllTemplates()
     call <SID>ExpandLicenseTemplates()
     call <SID>ExpandLanguageTemplates()
 
-    let l:cusor_found = <SID>MoveCursor()
+    let l:cursor_found = <SID>MoveCursor()
 
-    if !l:cusor_found
+    if !l:cursor_found
         normal `m " return to old cursor position
     endif
 endfunction


### PR DESCRIPTION
- Added documentation for recently introduced feature of recursively searching for template paths
- Restructured README file and fixed typos
- If templates are found in a particular directory a file called ``tmpl_settings.vim`` may be used to influence how the placeholders expand for this directory (see ``README.md`` for details).