### PR TITLE
fix expand bug

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -91,7 +91,8 @@ function <SID>ExpandOtherTemplates()
 endfunction
 
 function <SID>ExpandLicenseFile()
-    normal gg " go to first line
+    " go to first line
+    normal gg
     " serach for LICENSE_FILE
     if !(search('{{LICENSE_FILE}}', 'W'))
         return
@@ -99,7 +100,8 @@ function <SID>ExpandLicenseFile()
 
     let l:lineno = line('.')
     let l:colno = col('.')
-    s/{{LICENSE_FILE}}// " remove license file
+     " remove license file
+    s/{{LICENSE_FILE}}//
     call cursor(l:lineno, l:colno)
 
     " Expand lincense file
@@ -160,12 +162,14 @@ function <SID>ExpandLanguageTemplates()
 endfunction
 
 function <SID>MoveCursor()
-    normal gg " go to first line
+    " go to first line
+    normal gg
     " serach for cursor if it is found then move cursor there
     if (search('{{CURSOR}}', 'W'))
         let l:lineno = line('.')
         let l:colno = col('.')
-        s/{{CURSOR}}// " remove cursor
+        " remove cursor
+        s/{{CURSOR}}//
         call cursor(l:lineno, l:colno)
         return 1
     endif
@@ -174,7 +178,8 @@ endfunction
 
 " Expand all templates present in current file
 function <SID>ExpandAllTemplates()
-    "normal mm " mark the current position so that we can return to it if cursor is not found
+" mark the current position so that we can return to it if cursor is not found
+    normal mm
 
     call <SID>ExpandTimestampTemplates()
     call <SID>ExpandAuthoringTemplates()
@@ -183,11 +188,12 @@ function <SID>ExpandAllTemplates()
     "call <SID>ExpandLicenseTemplates()
     call <SID>ExpandLanguageTemplates()
 
-    "let l:cursor_found = <SID>MoveCursor()
+    let l:cursor_found = <SID>MoveCursor()
 
-    "if !l:cursor_found
-    ""    normal `m " return to old cursor position
-    "endif
+    if !l:cursor_found
+    " return to old cursor position
+        normal `m
+    endif
 endfunction
 
 " If the settings file exits in the template directory, then

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -174,20 +174,20 @@ endfunction
 
 " Expand all templates present in current file
 function <SID>ExpandAllTemplates()
-    normal mm " mark the current position so that we can return to it if cursor is not found
+    "normal mm " mark the current position so that we can return to it if cursor is not found
 
     call <SID>ExpandTimestampTemplates()
     call <SID>ExpandAuthoringTemplates()
     call <SID>ExpandFilePathTemplates()
     call <SID>ExpandOtherTemplates()
-    call <SID>ExpandLicenseTemplates()
+    "call <SID>ExpandLicenseTemplates()
     call <SID>ExpandLanguageTemplates()
 
-    let l:cursor_found = <SID>MoveCursor()
+    "let l:cursor_found = <SID>MoveCursor()
 
-    if !l:cursor_found
-        normal `m " return to old cursor position
-    endif
+    "if !l:cursor_found
+    ""    normal `m " return to old cursor position
+    "endif
 endfunction
 
 " If the settings file exits in the template directory, then
@@ -254,7 +254,7 @@ function <SID>InitializeTemplate(...)
     for l:path in l:tmpl_paths
         let l:initialized = <SID>InitializeTemplateForExtension(l:extension, l:path)
         if (l:initialized)
-            call <SID>ExpandAllTemplates()
+            "call <SID>ExpandAllTemplates()
             break
         endif
     endfor

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -178,14 +178,14 @@ endfunction
 
 " Expand all templates present in current file
 function <SID>ExpandAllTemplates()
-" mark the current position so that we can return to it if cursor is not found
+    " mark the current position so that we can return to it if cursor is not found
     normal mm
 
     call <SID>ExpandTimestampTemplates()
     call <SID>ExpandAuthoringTemplates()
     call <SID>ExpandFilePathTemplates()
     call <SID>ExpandOtherTemplates()
-    "call <SID>ExpandLicenseTemplates()
+    call <SID>ExpandLicenseTemplates()
     call <SID>ExpandLanguageTemplates()
 
     let l:cursor_found = <SID>MoveCursor()
@@ -260,7 +260,7 @@ function <SID>InitializeTemplate(...)
     for l:path in l:tmpl_paths
         let l:initialized = <SID>InitializeTemplateForExtension(l:extension, l:path)
         if (l:initialized)
-            "call <SID>ExpandAllTemplates()
+            call <SID>ExpandAllTemplates()
             break
         endif
     endfor


### PR DESCRIPTION
hello, there was some buggy code like `normal gg " go to first line` in the code.

This will result in a messy expand result.

The problem with it is that those comments after vim commands will be treated as commands. Please do not comment after vim commands.

This pull request has resolved this issue. Please merge it.