### PR TITLE
Add a CAMEL_CLASS template

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,6 @@ The Following placeholders are currently supported by this plugin
 - `MACRO_GUARD` : Macro guard for use in c/c++ files. `filename.h -> FILENAME_H`. All dots(.) and dashes (-) present in filename are converted into underscores (_).
 - `MACRO_GUARD_FULL` : Same as `MACRO_GUARD`, except relative path is used in place of file name. e.g. `relative/to/filename.h -> RELATIVE_TO_FILENAME_H`
 - `CLASS` : class name, same as `FILE`
-- `CLASS` : class name converted to camel case (first letters of words capitalized and underscores removed)
+- `CAMEL_CLASS` : class name converted to camel case (first letters of words capitalized and underscores removed)
 - `CURSOR` : This is a spacial placeholder, it does not expand into anything but the cursor is placed at this location after the template expansion
 

--- a/README.md
+++ b/README.md
@@ -163,5 +163,6 @@ The Following placeholders are currently supported by this plugin
 - `MACRO_GUARD` : Macro guard for use in c/c++ files. `filename.h -> FILENAME_H`. All dots(.) and dashes (-) present in filename are converted into underscores (_).
 - `MACRO_GUARD_FULL` : Same as `MACRO_GUARD`, except relative path is used in place of file name. e.g. `relative/to/filename.h -> RELATIVE_TO_FILENAME_H`
 - `CLASS` : class name, same as `FILE`
+- `CLASS` : class name converted to camel case (first letters of words capitalized and underscores removed)
 - `CURSOR` : This is a spacial placeholder, it does not expand into anything but the cursor is placed at this location after the template expansion
 

--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -22,7 +22,7 @@ endif
 " COMPANY:      COMAPNY
 " CURSOR:       CURSOR
 " LICENSE:      LICENSE, LICENSE_FILE, COPYRIGHT
-" LANGUAGES:    MACRO_GUARD, MACRO_GUARD_FULL, CLASS
+" LANGUAGES:    MACRO_GUARD, MACRO_GUARD_FULL, CLASS, CAMEL_CLASS
 
 function <SID>EscapeTemplate(tmpl)
     return escape(a:tmpl, '/')
@@ -34,6 +34,10 @@ endfunction
 
 function <SID>PrepareMacro(str)
     return toupper(tr(a:str, '/.-', '___'))
+endfunction
+
+function <SID>PrepareCamelClass(str)
+    return substitute(substitute(a:str, '\(^\|_\)\(\a\)', '\1\U\2', 'g'), '_', '', 'g')
 endfunction
 
 function <SID>ExpandTimestampTemplates()
@@ -155,10 +159,12 @@ function <SID>ExpandLanguageTemplates()
     let l:macro_guard = <SID>PrepareMacro(expand('%:t'))
     let l:macro_guard_full = <SID>PrepareMacro(@%)
     let l:filename = expand("%:t:r")
+    let l:camelclass = <SID>PrepareCamelClass(l:filename)
 
     call <SID>ExpandTemplate('MACRO_GUARD', l:macro_guard)
     call <SID>ExpandTemplate('MACRO_GUARD_FULL', l:macro_guard_full)
     call <SID>ExpandTemplate('CLASS', l:filename)
+    call <SID>ExpandTemplate('CAMEL_CLASS', l:camelclass)
 endfunction
 
 function <SID>MoveCursor()


### PR DESCRIPTION
Converts the filename from snake case to camel case, for languages like ruby and python that use this convention.