### PR TITLE
Fix conflict with vim-signature

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -185,7 +185,7 @@ endfunction
 " Expand all templates present in current file
 function <SID>ExpandAllTemplates()
     " mark the current position so that we can return to it if cursor is not found
-    normal mm
+    normal! mm
 
     call <SID>ExpandTimestampTemplates()
     call <SID>ExpandAuthoringTemplates()


### PR DESCRIPTION
vim-signature rebinds :normal m, and it really doesn't like being called during BufNewFile. switching the call from "normal mm" to "normal! mm" fixes the issue.

even without the conflict,, it's good practice or something.